### PR TITLE
Issues when trying to send url with parameters

### DIFF
--- a/lib/loaf/view_extensions.rb
+++ b/lib/loaf/view_extensions.rb
@@ -36,7 +36,7 @@ module Loaf
 
     def _process_url_for(url)
       if url.is_a?(String) || url.is_a?(Symbol)
-        return send url
+        return respond_to?(url) ? send(url) : url
       else
         return url
       end


### PR DESCRIPTION
This did not work at all for me.

``` ruby
breadcrumb "#{@category.title}", 'blog_category_path(@category)'
```

I would get "Invalid method 'blog_category_path(@category)' " because send does not allow sending arugment's unless they are seperated ie. send(:blog_category_path, @category)

I made a change to just allow sending in the actual url (as a string)
so: 

``` ruby
breadcrumb "#{@category.title}", 'blog_category_path(@category)'
```

becomes:

``` ruby
breadcrumb "#{@category.title}", blog_category_path(@category)
```
