### PR TITLE
Change to resolve error when url is 'nil'

### DIFF
--- a/lib/loaf/view_extensions.rb
+++ b/lib/loaf/view_extensions.rb
@@ -52,7 +52,7 @@ module Loaf
       options = Loaf.configuration.to_hash.merge(options)
       _breadcrumbs.each do |crumb|
         name = format_name(crumb.name, options)
-        path = url_for(_expand_url(crumb.url))
+        path = crumb.url.nil? ? "#" : url_for(_expand_url(crumb.url))
         current = current_crumb?(path, crumb.match)
 
         yield(Loaf::Breadcrumb[name, path, current])


### PR DESCRIPTION
When running tests with RSpec & Capybara we ([Punchpass](https://punchpass.com)) were encountering the following error:
```bash
Failures:

  1) Customer signs in via the company sign in page having a customer account with the company with an instance param is taken to the member instance details page
     Failure/Error: - breadcrumb_trail crumb_length: 60 do |name, url, styles|
     
     ActionView::Template::Error:
       arguments passed to url_for can't be handled. Please require routes or provide your own implementation
     # /Users/dan/.asdf/installs/ruby/2.4.2/lib/ruby/gems/2.4.0/gems/actionview-4.2.8/lib/action_view/helpers/url_helper.rb:38:in `url_for'
     # /Users/dan/.asdf/installs/ruby/2.4.2/lib/ruby/gems/2.4.0/gems/loaf-0.6.0/lib/loaf/view_extensions.rb:55:in `block in breadcrumb_trail'
     # /Users/dan/.asdf/installs/ruby/2.4.2/lib/ruby/gems/2.4.0/gems/loaf-0.6.0/lib/loaf/view_extensions.rb:53:in `each'
     # /Users/dan/.asdf/installs/ruby/2.4.2/lib/ruby/gems/2.4.0/gems/loaf-0.6.0/lib/loaf/view_extensions.rb:53:in `breadcrumb_trail'
     # ./app/views/layouts/member_area.html.slim:50:in `_app_views_layouts_member_area_html_slim__403637215859839844_70256255168280'
```

After a bit of digging, I found the cause to be a nil value in the url for our last breadcrumb. Interestingly, the error didn't trip in development or production, just testing. Adding the nil check allowed our tests to pass gracefully.