### PR TITLE
Do not modify the options hash

### DIFF
--- a/lib/loaf/crumb.rb
+++ b/lib/loaf/crumb.rb
@@ -12,7 +12,7 @@ module Loaf
     def initialize(name, url, options = {})
       @name  = name
       @url   = url
-      @match = options.delete(:match) { :inclusive }
+      @match = options.fetch(:match, :inclusive)
       freeze
     end
   end # Crumb


### PR DESCRIPTION
The options hash is passed down by rails and is cached. This means that
if one deletes from it, on the next call it will not have the previous
options anymore, thus losing the configuration.

Closes #13