### PR TITLE
adds nil guard and clear error messages to Crumb initialization.

### DIFF
--- a/lib/loaf/crumb.rb
+++ b/lib/loaf/crumb.rb
@@ -10,6 +10,9 @@ module Loaf
     attr_reader :match
 
     def initialize(name, url, options = {})
+      raise ArgumentError, "first argument, `name`, cannot be nil" if name.nil?
+      raise ArgumentError, "second argument, `url`, cannot be nil" if url.nil?
+
       @name  = name
       @url   = url
       @match = options.delete(:match) { :inclusive }


### PR DESCRIPTION
Sorry for the long hiatus after the last PR. Based on your feedback, I've added some error handling to `Loaf::Crumb#initialize`.

ref: https://github.com/piotrmurach/loaf/pull/11

This error:

```ruby
  1) Customer signs in via the company sign in page having a customer account with the company with an instance param is taken to the member instance details page
     Failure/Error: - breadcrumb_trail crumb_length: 60 do |name, url, current|
     
     ActionView::Template::Error:
       arguments passed to url_for can't be handled. Please require routes or provide your own implementation
     # /Users/dan/grillwork/loaf/lib/loaf/view_extensions.rb:57:in `block in breadcrumb_trail'
     # /Users/dan/grillwork/loaf/lib/loaf/view_extensions.rb:55:in `each'
     # /Users/dan/grillwork/loaf/lib/loaf/view_extensions.rb:55:in `breadcrumb_trail'
     # ./app/views/layouts/member_area.html.slim:52:in `_app_views_layouts_member_area_html_slim__290762266190123875_70211764360280'
     # ./app/controllers/members/class_details_controller.rb:53:in `instance_details'
     # ./lib/subdomain/middleware.rb:42:in `call'
     # ./lib/auth/middleware.rb:8:in `call'
     # ./spec/features/auth/customer_signs_in_spec.rb:20:in `block (5 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   arguments passed to url_for can't be handled. Please require routes or provide your own implementation
     #   /Users/dan/grillwork/loaf/lib/loaf/view_extensions.rb:57:in `block in breadcrumb_trail'
```

Becomes this error:

```ruby
  1) Customer signs in via the company sign in page having a customer account with the company with an instance param is taken to the member instance details page
     Failure/Error: breadcrumb("... name here ...", nil)
     
     ArgumentError:
       second argument, `url`, cannot be nil
     # /Users/dan/grillwork/loaf/lib/loaf/crumb.rb:14:in `initialize'
     # /Users/dan/grillwork/loaf/lib/loaf/controller_extensions.rb:62:in `new'
     # /Users/dan/grillwork/loaf/lib/loaf/controller_extensions.rb:62:in `breadcrumb'
     # ./app/controllers/members/class_details_controller.rb:29:in `instance_details'
     # ./lib/subdomain/middleware.rb:42:in `call'
     # ./lib/auth/middleware.rb:8:in `call'
     # ./spec/features/auth/customer_signs_in_spec.rb:20:in `block (5 levels) in <top (required)>'
```

Not only is the error easier to understand, but the trace now includes the line on which the error occurred.