### PR TITLE
Add 'match' to Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ There is a small set of custom opinionated defaults. The following options are v
 ```ruby
 :capitalize    # set breadcrumbs to have initial letter uppercase, default false
 :crumb_length  # breadcrumb length in integer, default length is 30 characters
+:match         # set match type, default :inclusive
 ```
 
 You can override them in your views by passing them to the view `breadcrumb` helper

--- a/lib/loaf/configuration.rb
+++ b/lib/loaf/configuration.rb
@@ -5,7 +5,8 @@ module Loaf
     VALID_ATTRIBUTES = [
       :locales_path,
       :crumb_length,
-      :capitalize
+      :capitalize,
+      :match
     ].freeze
 
     attr_accessor(*VALID_ATTRIBUTES)
@@ -19,6 +20,8 @@ module Loaf
     DEFAULT_LAST_CRUMB_LINKED = false
 
     DEFAULT_CAPITALIZE = false
+
+    DEFAULT_MATCH = :inclusive
 
     DEFAULT_ROOT = true
 

--- a/lib/loaf/crumb.rb
+++ b/lib/loaf/crumb.rb
@@ -13,7 +13,7 @@ module Loaf
     def initialize(name, url, options = {})
       @name  = name || raise_name_error
       @url   = url || raise_url_error
-      @match = options.fetch(:match, :inclusive)
+      @match = options.fetch(:match, Loaf.configuration.match)
       freeze
     end
 

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -5,15 +5,18 @@ RSpec.describe Loaf::Configuration do
     config = Loaf::Configuration.new
 
     config.crumb_length = 4
-
     expect(config.crumb_length).to eq(4)
+
+    config.match = :exact
+    expect(config.match).to eq(:exact)
   end
 
   it "accepts attributes at initialization" do
-    options = { crumb_length: 12 }
+    options = { crumb_length: 12, match: :exact }
     config = Loaf::Configuration.new(options)
 
     expect(config.crumb_length).to eq(12)
+    expect(config.match).to eq(:exact)
   end
 
   it "exports configuration as hash" do
@@ -21,7 +24,8 @@ RSpec.describe Loaf::Configuration do
     expect(config.to_hash).to eq({
       capitalize: false,
       crumb_length: 30,
-      locales_path: '/'
+      locales_path: '/',
+      match: :inclusive
     })
   end
 


### PR DESCRIPTION
I touch these
 - `README.md`: add `match` to Configuration
 - `configuration.rb`, `crumb.rb`: for this function
 - `configuration_spec.rb`: for test, i did open other specs but i could not found spec for this function. so i just add this one file

from: https://github.com/piotrmurach/loaf/issues/18