### PR TITLE
Add instance exec for breadcrumbs

### DIFF
--- a/lib/loaf/controller_extensions.rb
+++ b/lib/loaf/controller_extensions.rb
@@ -43,7 +43,7 @@ module Loaf
         case name
         when NilClass
         when Proc
-          name.call(instance)
+          instance.instance_exec instance, &name
         else
           name
         end

--- a/spec/integration/breadcrumb_trail_spec.rb
+++ b/spec/integration/breadcrumb_trail_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe "breadcrumbs trail" do
     end
   end
 
+  it "shows breadcrumbs using instance variables" do
+    visit post_path(1)
+
+    within "#breadcrumbs" do
+      expect(page.html).to include('<a href="/posts/3735928559">3735928559</a>')
+    end
+  end
+
   it 'is current when forced' do
     visit new_post_path
 

--- a/spec/rails_app/app/controllers/posts_controller.rb
+++ b/spec/rails_app/app/controllers/posts_controller.rb
@@ -1,6 +1,11 @@
 class Post < Struct.new(:id); end
 
 class PostsController < ApplicationController
+  before_filter :load_post
+
+  breadcrumb ->(_) { @special_post.id.to_s },
+             ->(_) { post_path(@special_post.id) }, only: [:show]
+
   def index
     breadcrumb 'all_posts', posts_path
   end
@@ -16,5 +21,11 @@ class PostsController < ApplicationController
 
   def create
     render action: :new
+  end
+
+  private
+
+  def load_post
+    @special_post = ::Post.new(0xDEADBEEF)
   end
 end


### PR DESCRIPTION
Hello :wave: 

This is something I've been sorely missing in `loaf`, as using the controller to load 2/3 different models gets quickly cumbersome and not all that pretty.

This is as far as I am aware a backwards compatible change. Since people shouldn't have defined instance variables in the breadcrumbs before.

Now one can simply do `breadcrumb ->(c) { @user.name }, user_path` or so. This simplifies the whole thing.