### PR TITLE
Add breadcrumbs method

### DIFF
--- a/lib/loaf/controller_extensions.rb
+++ b/lib/loaf/controller_extensions.rb
@@ -16,7 +16,9 @@ module Loaf
     module ClassMethods
       # Add breacrumb to the trail in controller as class method
       #
-      # @param [String]
+      # @param [String] name
+      #
+      # @param [Object] url
       #
       # @api public
       def breadcrumb(name, url, options = {})

--- a/lib/loaf/controller_extensions.rb
+++ b/lib/loaf/controller_extensions.rb
@@ -29,6 +29,15 @@ module Loaf
       end
       alias add_breadcrumb breadcrumb
 
+      # Provide a scope to add multiple breadcrumbs to the trail in controller as class method
+      #
+      # @api public
+      def breadcrumbs(options = {}, &block)
+        send(_filter_name, options) do |instance|
+          instance.instance_exec(&block)
+        end
+      end
+
       private
 
       # Choose available filter name


### PR DESCRIPTION
This one might seem like a weird requirement at first, but say I want to define several breadcrumbs at once (as in the case of recursive breadcrumbs). Using this patch I can do the following:

```
breadcrumbs do
  folder.ancestors.each do |ancestor|
    breadcrumb ancestor.name, [:admin, ancestor, :contents]
  end
end
```

This allows me to use instance methods (such as the ones `decent_exposure` provides) directly within the block (in this case `folder` is defined in the class as an instance method). It also works where the instance methods are defined in sub-classes and the `breadcrumbs` call is made in a superclass, allowing us to hand off the creation of that instance method to the sub-class. I think that last point works because of the use of `before_action`. It's a neat trick!

I've given it some quick documentation but didn't know how to document the fact that it needs to be passed a block. I also couldn't think of where to test this. If you had some pointers for me that would be great, otherwise I'm happy for you to jump in and add some tests.

I've actually tested this in my application and it works really well!

Fixes #23