### PR TITLE
Add helper & controller method #breadcrumb_names, with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ end
 
 Assume `ancestors` method is defined inside the controller.
 
+You can access an array of the names pushed into the breadcrumb trail, in order of addition, with controller method `breadcrumb_names`. This can be handy for generating meaningful page titles from breadcrumb data.
+
 #### 2.1.2 view
 
 **Loaf** adds `breadcrumb` helper also to the views. Together with controller breadcrumbs, the view breadcrumbs are appended as the last in breadcrumb trail. For instance, to specify view breadcrumb do:
@@ -266,6 +268,8 @@ and if you are using HAML do:
 ```
 
 Usually best practice is to put such snippet inside its own `_breadcrumbs.html.erb` partial.
+
+As with controllers, can access an array of the names pushed into the breadcrumb trail, in order of addition, with helper method `breadcrumb_names`. This can be handy for generating meaningful page titles from breadcrumb data. Use whichever of the two is more convenient given your application structure and coding style.
 
 ## 3. Configuration
 

--- a/lib/loaf/controller_extensions.rb
+++ b/lib/loaf/controller_extensions.rb
@@ -11,6 +11,7 @@ module Loaf
       base.extend ClassMethods
       base.send :include, InstanceMethods
       base.send :helper_method, :_breadcrumbs
+      base.send :helper_method, :breadcrumb_names
     end
 
     module ClassMethods
@@ -70,6 +71,14 @@ module Loaf
         _breadcrumbs << Loaf::Crumb.new(name, url, options)
       end
       alias add_breadcrumb breadcrumb
+
+      # Array of breadcrumb names, in case you need them elsewhere - e.g. to
+      # build a helpful <title>...</title> attribute.
+      #
+      # @api public
+      def breadcrumb_names
+        _breadcrumbs.map(&:name)
+      end
 
       # Collection of breadcrumbs
       #

--- a/lib/loaf/view_extensions.rb
+++ b/lib/loaf/view_extensions.rb
@@ -39,6 +39,14 @@ module Loaf
     end
     alias add_breadcrumb breadcrumb
 
+    # Returns an array of breadcrumb names, in case you need them elsewhere -
+    # e.g. to build a helpful <title>...</title> attribute.
+    #
+    # @api public
+    def breadcrumb_names
+      _breadcrumbs.map(&:name)
+    end
+
     # Renders breadcrumbs inside view.
     #
     # @param [Hash] options

--- a/spec/unit/controller_extensions_spec.rb
+++ b/spec/unit/controller_extensions_spec.rb
@@ -50,5 +50,25 @@ RSpec.describe Loaf::ControllerExtensions do
         instance.breadcrumb(name, url)
       }.to change { instance._breadcrumbs.size }.by(1)
     end
+
+    context '#breadcrumb_names' do
+      it 'returns an empty array initially' do
+        instance = DummyController.new
+
+        expect(instance.breadcrumb_names).to be_empty
+      end
+
+      it 'returns all names in order' do
+        instance = DummyController.new
+        names    = ['Home', 'Users', 'Edit user']
+        url      = [:home_path, :users_path, :edit_users_path]
+
+        0.upto(2) do |index|
+          instance.breadcrumb(names[index], url[index])
+        end
+
+        expect(instance.breadcrumb_names).to eql(names)
+      end
+    end
   end
 end

--- a/spec/unit/view_extensions/breadcrumb_names_spec.rb
+++ b/spec/unit/view_extensions/breadcrumb_names_spec.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+RSpec.describe Loaf::ViewExtensions, '.breadcrumb_names' do
+
+  it { expect(DummyView.new).to respond_to(:breadcrumb_names) }
+
+  it 'returns an empty array initially' do
+    instance = DummyView.new
+
+    expect(instance.breadcrumb_names).to be_empty
+  end
+
+  it 'returns all names in order' do
+    instance = DummyView.new
+    names    = ['Home', 'Users', 'Edit user']
+    url      = [:home_path, :users_path, :edit_users_path]
+
+    0.upto(2) do |index|
+      instance.breadcrumb(names[index], url[index])
+    end
+
+    expect(instance.breadcrumb_names).to eql(names)
+  end
+end


### PR DESCRIPTION
### Describe the change
This adds helper `breadcrumb_names` for views and corresponding method for controllers.

### Why are we doing this?
Our site makes use of Loaf for breadcrumbs, but prior to this change didn't have any way to reuse that data for `title` attributes in the HTML. Using `_breadcrumbs.last.name` was helpful here, but we wanted to make this an 'official' public API rather than using the internal stuff.

### Benefits
Other users can apply similar changes, or use the name(s) array in ways we haven't considered.

### Drawbacks
Bloats the API by one method call.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
