### PR TITLE
Reduce gem dependencies to `railties`

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,4 +1,4 @@
-rails_versions = [
+railties_versions = [
   %w[3.2 3.2.22.5],
   %w[4.0 4.0.13],
   %w[4.1 4.1.16],
@@ -9,11 +9,11 @@ rails_versions = [
   %w[6.0 6.0.2],
 ]
 
-rails_versions.each do |(version, rails)|
+railties_versions.each do |(version, railties)|
   gem_version = Gem::Version.new(version)
 
-  appraise "rails#{version}" do
-    gem "rails", "~> #{rails}"
+  appraise "railties#{version}" do
+    gem "railties", "~> #{railties}"
     gem "capybara", "~> 2.18.0"
 
     if gem_version <= Gem::Version.new("4.0")

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.3.13", platforms: :ruby
-gem "rails", "~> 3.2.22.5"
+gem "railties", "~> 3.2.22.5"
 gem "test-unit", "~> 3.0"
 
 group :metrics do

--- a/gemfiles/rails4.0.gemfile
+++ b/gemfiles/rails4.0.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.3.13", platforms: :ruby
-gem "rails", "~> 4.0.13"
+gem "railties", "~> 4.0.13"
 gem "test-unit", "~> 3.0"
 
 group :metrics do

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.3.13", platforms: :ruby
-gem "rails", "~> 4.1.16"
+gem "railties", "~> 4.1.16"
 
 group :metrics do
   gem "coveralls", "0.8.23"

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.3.13", platforms: :ruby
-gem "rails", "~> 4.2.10"
+gem "railties", "~> 4.2.10"
 
 group :metrics do
   gem "coveralls", "0.8.23"

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.3.13", platforms: :ruby
-gem "rails", "~> 5.0.7"
+gem "railties", "~> 5.0.7"
 
 group :metrics do
   gem "coveralls", "0.8.23"

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.3.13", platforms: :ruby
-gem "rails", "~> 5.1.6"
+gem "railties", "~> 5.1.6"
 
 group :metrics do
   gem "coveralls", "0.8.23"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.3.13", platforms: :ruby
-gem "rails", "~> 5.2.0"
+gem "railties", "~> 5.2.0"
 
 group :metrics do
   gem "coveralls", "0.8.23"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -9,7 +9,7 @@ gem "capybara", "~> 2.18.0"
 gem "rspec-rails", "~> 3.9.0"
 gem "public_suffix", "~> 2.0.5"
 gem "sqlite3", "~> 1.4.2", platforms: :ruby
-gem "rails", "~> 6.0.2"
+gem "railties", "~> 6.0.2"
 
 group :metrics do
   gem "coveralls", "0.8.23"

--- a/loaf.gemspec
+++ b/loaf.gemspec
@@ -25,8 +25,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 1.9.3"
 
-  spec.add_dependency "rails", ">= 3.2"
+  spec.add_dependency "railties", ">= 3.2"
 
   spec.add_development_dependency "bundler", ">= 1.5"
+  spec.add_development_dependency "rails", ">= 3.2"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
### Describe the change
Currently the gem depends on the entirety of `rails`, which adds some
"dependency weight" to projects that only need a subset of Rails
functionality. This changes the gem to depend on `railties` instead,
which covers all of the core Rails functionality Loaf needs to function.

### Why are we doing this?
Fixes issue #44 

### Benefits
Installing Loaf will no longer lead to additional Rails sub-gems being installed beyond what Loaf needs to function (e.g. `actioncable`, `active storage` etc.) beyond what the host application requires.

### Drawbacks
- A very edge-y edge case could be apps that rely on some parts of Rails that Loaf previously added an implicit dependency for
- It's difficult to do automated testing for this change - I've tested my application that uses Loaf locally against this change, and it worked fine, as did the test Rails app but that obviously requires all of Rails (and I don't necessarily want to change that given that it's what most users are likely to be doing)

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
