### PR TITLE
Stop using deprecated URI.parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * Reduce gem dependencies to `railties` by Christian Sutter (@csutter)
+* Use `URI::DEFAULT_PARSER` instead of deprecated `URI.parser` by (@dsazup)
 
 ### Fixed
 * Fix #breadcrumb_trail to allow overriding the match option

--- a/lib/loaf/view_extensions.rb
+++ b/lib/loaf/view_extensions.rb
@@ -68,10 +68,10 @@ module Loaf
     def current_crumb?(path, pattern = :inclusive)
       return false unless request.get? || request.head?
 
-      origin_path = URI.DEFAULT_PARSER.unescape(path).force_encoding(Encoding::BINARY)
+      origin_path = URI::DEFAULT_PARSER.unescape(path).force_encoding(Encoding::BINARY)
 
       request_uri = request.fullpath
-      request_uri = URI.DEFAULT_PARSER.unescape(request_uri)
+      request_uri = URI::DEFAULT_PARSER.unescape(request_uri)
       request_uri.force_encoding(Encoding::BINARY)
 
       # strip away trailing slash

--- a/lib/loaf/view_extensions.rb
+++ b/lib/loaf/view_extensions.rb
@@ -68,10 +68,10 @@ module Loaf
     def current_crumb?(path, pattern = :inclusive)
       return false unless request.get? || request.head?
 
-      origin_path = URI.parser.unescape(path).force_encoding(Encoding::BINARY)
+      origin_path = URI.DEFAULT_PARSER.unescape(path).force_encoding(Encoding::BINARY)
 
       request_uri = request.fullpath
-      request_uri = URI.parser.unescape(request_uri)
+      request_uri = URI.DEFAULT_PARSER.unescape(request_uri)
       request_uri.force_encoding(Encoding::BINARY)
 
       # strip away trailing slash


### PR DESCRIPTION
### Describe the change

Use recommended way to get the parser `URI::DEFAULT_PARSER` instead of deprecated `URI.parser`

### Why are we doing this?
It has been deprecated in https://github.com/rails/rails/pull/39733 


### Benefits
Stops throwing a warning on 6.1 alpha.

### Drawbacks
None

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & **passing locally**?
[x] Code style checked?
[] Rebased with `master` branch?
[] Documentaion updated?
