### PR TITLE
Add get_only option

### DIFF
--- a/lib/loaf/configuration.rb
+++ b/lib/loaf/configuration.rb
@@ -4,7 +4,8 @@ module Loaf
   class Configuration
     VALID_ATTRIBUTES = [
       :locales_path,
-      :match
+      :match,
+      :get_only
     ].freeze
 
     attr_accessor(*VALID_ATTRIBUTES)
@@ -12,6 +13,8 @@ module Loaf
     DEFAULT_LOCALES_PATH = '/'
 
     DEFAULT_MATCH = :inclusive
+
+    DEFAULT_GET_ONLY = true
 
     # Setup this configuration
     #

--- a/lib/loaf/crumb.rb
+++ b/lib/loaf/crumb.rb
@@ -10,6 +10,8 @@ module Loaf
 
     attr_reader :match
 
+    attr_reader :get_only
+
     def initialize(name, url, options = {})
       @name  = name || raise_name_error
       @url   = url || raise_url_error

--- a/lib/loaf/view_extensions.rb
+++ b/lib/loaf/view_extensions.rb
@@ -52,7 +52,11 @@ module Loaf
       _breadcrumbs.each do |crumb|
         name = title_for(crumb.name)
         path = url_for(_expand_url(crumb.url))
-        current = current_crumb?(path, options.fetch(:match) { crumb.match })
+        current = current_crumb?(
+          path,
+          options.fetch(:match) { crumb.match },
+          options.fetch(:get_only) { crumb.get_only }
+        )
 
         yield(Loaf::Breadcrumb[name, path, current])
       end
@@ -65,8 +69,8 @@ module Loaf
     #   the pattern to match on
     #
     # @api public
-    def current_crumb?(path, pattern = :inclusive)
-      return false unless request.get? || request.head?
+    def current_crumb?(path, pattern = :inclusive, get_only = true)
+      return false unless !get_only || request.get? || request.head?
 
       origin_path = URI::DEFAULT_PARSER.unescape(path).force_encoding(Encoding::BINARY)
 

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Loaf::Configuration do
   it "exports configuration as hash" do
     config = Loaf::Configuration.new
     expect(config.to_hash).to eq({
+      get_only: true,
       locales_path: "/",
       match: :inclusive
     })


### PR DESCRIPTION
### Describe the change
Add a `get_only` option to `breadcrumb` parameters

### Why are we doing this?
When I use this gem on some legacy projects, I met a circumstance which I have to show breadcrumbs on POST/PATCH action.

```
breadcrumb 'Sign In',  :login_path

def create
  # ...
  render :login_step_2
end
```

### Benefits
Now I can make it work by using `get_only` option

```
breadcrumb 'Sign In',  :login_path, get_only: false

def create
  # ...
  render :login_step_2
end
```

`get_only` default value is true

